### PR TITLE
feat: crash reporting

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -77,6 +77,7 @@ PODS:
   - hermes-engine (0.70.5)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
+  - PLCrashReporter (1.11.0)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -381,6 +382,7 @@ PODS:
   - SocketRocket (0.6.0)
   - splunk-otel-react-native (0.1.0-alpha.1):
     - DeviceKit (~> 4.0)
+    - PLCrashReporter (~> 1.11)
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -466,6 +468,7 @@ SPEC REPOS:
     - fmt
     - libevent
     - OpenSSL-Universal
+    - PLCrashReporter
     - SocketRocket
     - YogaKit
 
@@ -566,6 +569,7 @@ SPEC CHECKSUMS:
   hermes-engine: 7fe5fc6ef707b7fdcb161b63898ec500e285653d
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
+  PLCrashReporter: 7a9dff14a23ba5d2e28c6160f0bb6fada5e71a8d
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: 21229f84411088e5d8538f21212de49e46cc83e2
   RCTTypeSafety: 62eed57a32924b09edaaf170a548d1fc96223086
@@ -596,7 +600,7 @@ SPEC CHECKSUMS:
   ReactCommon: c9246996e73bf75a2c6c3ff15f1e16707cdc2da9
   RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  splunk-otel-react-native: e0153f4c238f07bb73f3c978baf003572018515e
+  splunk-otel-react-native: 7a4aaad4cbd3dafb23813e23093a4e55ab25a17d
   Yoga: eca980a5771bf114c41a754098cd85e6e0d90ed7
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/ios/CrashReporting.swift
+++ b/ios/CrashReporting.swift
@@ -1,0 +1,193 @@
+//
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import CrashReporter
+
+let CrashReportingVersionString = "0.5.0"
+
+var TheCrashReporter: PLCrashReporter?
+private var customDataDictionary = RWLocked<[String: String]>(initialValue: [:])
+private var spanExporter: SpanExporter = NoopExporter()
+
+func initializeCrashReporting(exporter: SpanExporter) {
+    spanExporter = exporter
+    var startupSpan = newSpan(name: "SplunkIosReactNativeCrashReporting")
+    startupSpan.setAttribute(key: "component", value: "appstart")
+    defer {
+        endSpan(exporter: spanExporter, startupSpan)
+    }
+    let config = PLCrashReporterConfig(signalHandlerType: .BSD, symbolicationStrategy: PLCrashReporterSymbolicationStrategy(rawValue: 0) /* none */)
+    let crashReporter_ = PLCrashReporter(configuration: config)
+    if crashReporter_ == nil {
+        startupSpan.setAttribute(key: "error.message", value: "Cannot construct PLCrashReporter")
+        print("Cannot construct PLCrashReporter")
+        return
+    }
+    let crashReporter = crashReporter_!
+    let success = crashReporter.enable()
+    print("PLCrashReporter enabled: "+success.description)
+    if !success {
+        startupSpan.setAttribute(key: "error.message", value: "Cannot enable PLCrashReporter")
+        return
+    }
+    TheCrashReporter = crashReporter
+    updateDeviceStats()
+    startPollingForDeviceStats()
+    // Now for the pending report if there is one
+    if !crashReporter.hasPendingCrashReport() {
+        print("no crash report")
+        return
+    }
+    print("Had a pending crash report")
+    do {
+        let data = crashReporter.loadPendingCrashReportData()
+        try loadPendingCrashReport(data)
+    } catch {
+        print("Error loading crash report: \(error)")
+        startupSpan.setAttribute(key: "error.message", value: "Cannot load crash report")
+        // yes, fall through to purge
+    }
+    crashReporter.purgePendingCrashReport()
+
+}
+
+func updateCrashReportSessionId(_ id: String) {
+   do {
+       customDataDictionary.with_write_access { dict in
+           dict["sessionId"] = id
+       }
+       let customData = try NSKeyedArchiver.archivedData(
+           withRootObject: customDataDictionary.read(),
+            requiringSecureCoding: false
+       )
+       TheCrashReporter?.customData = customData
+   } catch {
+        // We have failed to archive the custom data dictionary.
+        print("Failed to add the sessionId to the crash reports custom data.")
+   }
+}
+
+private func updateDeviceStats() {
+    do {
+        customDataDictionary.with_write_access { dict in
+            dict["batteryLevel"] = DeviceStats.batteryLevel
+            dict["freeDiskSpace"] = DeviceStats.freeDiskSpace
+            dict["freeMemory"] = DeviceStats.freeMemory
+        }
+        let customData = try NSKeyedArchiver.archivedData(
+            withRootObject: customDataDictionary.read(),
+            requiringSecureCoding: false
+        )
+        TheCrashReporter?.customData = customData
+    } catch {
+        // We have failed to archive the custom data dictionary.
+        print("Failed to add the device stats to the crash reports custom data.")
+    }
+}
+
+/*
+ Will poll every 5 seconds to update the device stats.
+ */
+private func startPollingForDeviceStats() {
+    let repeatSeconds: Double = 5
+    DispatchQueue.global(qos: .background).async {
+        let timer = Timer.scheduledTimer(withTimeInterval: repeatSeconds, repeats: true) { _ in
+            updateDeviceStats()
+        }
+        timer.fire()
+    }
+}
+
+func loadPendingCrashReport(_ data: Data!) throws {
+    print("Loading crash report of size \(data?.count as Any)")
+    let report = try PLCrashReport(data: data)
+    var exceptionType = report.signalInfo.name
+    if report.hasExceptionInfo {
+        exceptionType = report.exceptionInfo.exceptionName
+    }
+    // Turn the report into a span
+    let span = newSpan(name: exceptionType ?? "unknown")
+    span.setAttribute(key: "component", value: "crash")
+    if report.customData != nil {
+        let customData = NSKeyedUnarchiver.unarchiveObject(with: report.customData) as? [String: String]
+        if customData != nil {
+            span.setAttribute(key: "crash.rumSessionId", value: customData!["sessionId"] ?? "")
+            span.setAttribute(key: "crash.batteryLevel", value: customData!["batteryLevel"] ?? "0")
+            span.setAttribute(key: "crash.freeDiskSpace", value: customData!["freeDiskSpace"] ?? "0")
+            span.setAttribute(key: "crash.freeMemory", value: customData!["freeMemory"] ?? "0")
+        } else {
+            span.setAttribute(key: "crash.rumSessionId", value: String(decoding: report.customData, as: UTF8.self))
+        }
+    }
+    // "marketing version" here matches up to our use of CFBundleShortVersionString
+    span.setAttribute(key: "crash.app.version", value: report.applicationInfo.applicationMarketingVersion)
+    span.setAttribute(key: "error", value: true)
+    span.addEvent(name: "crash.timestamp", timestamp: report.systemInfo.timestamp)
+    span.setAttribute(key: "exception.type", value: exceptionType ?? "unknown")
+    span.setAttribute(key: "crash.address", value: report.signalInfo.address.description)
+    for case let thread as PLCrashReportThreadInfo in report.threads where thread.crashed {
+        span.setAttribute(key: "exception.stacktrace", value: crashedThreadToStack(report: report, thread: thread))
+        break
+    }
+    if report.hasExceptionInfo {
+        span.setAttribute(key: "exception.type", value: report.exceptionInfo.exceptionName)
+        span.setAttribute(key: "exception.message", value: report.exceptionInfo.exceptionReason)
+    }
+    
+    endSpan(exporter: spanExporter, span)
+}
+
+// FIXME this is a messy copy+paste of select bits of PLCrashReportTextFormatter
+func crashedThreadToStack(report: PLCrashReport, thread: PLCrashReportThreadInfo) -> String {
+    let text = NSMutableString()
+    text.appendFormat("Thread %ld", thread.threadNumber)
+    var frameNum = 0
+    while frameNum < thread.stackFrames.count {
+        let str = formatStackFrame(
+            // swiftlint:disable:next force_cast
+            frame: thread.stackFrames[frameNum] as! PLCrashReportStackFrameInfo,
+            frameNum: frameNum,
+            report: report)
+        text.append(str)
+        text.append("\n")
+        frameNum += 1
+    }
+    return String(text)
+}
+
+func formatStackFrame(frame: PLCrashReportStackFrameInfo, frameNum: Int, report: PLCrashReport) -> String {
+    var baseAddress: UInt64 = 0
+    var pcOffset: UInt64 = 0
+    var imageName = "???"
+    var symbolString: String?
+    let imageInfo = report.image(forAddress: frame.instructionPointer)
+    if imageInfo != nil {
+        imageName = imageInfo!.imageName
+        imageName = URL(fileURLWithPath: imageName).lastPathComponent
+        baseAddress = imageInfo!.imageBaseAddress
+        pcOffset = frame.instructionPointer - imageInfo!.imageBaseAddress
+    }
+    if frame.symbolInfo != nil {
+        let symbolName = frame.symbolInfo.symbolName
+        let symOffset = frame.instructionPointer - frame.symbolInfo.startAddress
+        symbolString =  String(format: "%@ + %ld", symbolName!, symOffset)
+    } else {
+        symbolString = String(format: "0x%lx + %ld", baseAddress, pcOffset)
+    }
+    return String(format: "%-4ld%-35@ 0x%016lx %@", frameNum, imageName, frame.instructionPointer, symbolString!)
+}

--- a/ios/CrashReporting.swift
+++ b/ios/CrashReporting.swift
@@ -18,8 +18,6 @@ limitations under the License.
 import Foundation
 import CrashReporter
 
-let CrashReportingVersionString = "0.5.0"
-
 var TheCrashReporter: PLCrashReporter?
 private var customDataDictionary = RWLocked<[String: String]>(initialValue: [:])
 private var spanExporter: SpanExporter = NoopExporter()

--- a/ios/DeviceStats.swift
+++ b/ios/DeviceStats.swift
@@ -1,0 +1,65 @@
+//
+/*
+Copyright 2023 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import System
+import UIKit
+
+internal class DeviceStats {
+    class var batteryLevel: String {
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        let level = abs(UIDevice.current.batteryLevel * 100)
+        return "\(level)%"
+    }
+    class var freeDiskSpace: String {
+        do {
+            let systemAttributes = try FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory() as String)
+            let maybeFreeSpace = (systemAttributes[FileAttributeKey.systemFreeSize] as? NSNumber)?.int64Value
+            guard let freeSpace = maybeFreeSpace else {
+                return "Unknown"
+            }
+            return ByteCountFormatter.string(fromByteCount: freeSpace, countStyle: .file)
+        } catch {
+            return "Unknown"
+        }
+    }
+    // https://stackoverflow.com/questions/5012886/determining-the-available-amount-of-ram-on-an-ios-device/8540665#8540665
+    class var freeMemory: String {
+        var usedBytes: Float = 0
+        let totalBytes = Float(ProcessInfo.processInfo.physicalMemory)
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let kerr: kern_return_t = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
+                task_info(
+                        mach_task_self_,
+                        task_flavor_t(MACH_TASK_BASIC_INFO),
+                        $0,
+                        &count
+                )
+            }
+        }
+        if kerr == KERN_SUCCESS {
+            usedBytes = Float(info.resident_size)
+        } else {
+            return "Unknown"
+        }
+        let freeBytes = totalBytes - usedBytes
+        return ByteCountFormatter.string(fromByteCount: Int64(freeBytes), countStyle: .memory)
+    }
+
+}

--- a/ios/Globals.swift
+++ b/ios/Globals.swift
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+fileprivate var globalAttributes = RWLocked<[String:TagValue]>(initialValue: [:])
+fileprivate var sessionId = RWLocked<String>(initialValue: "")
+
+struct Globals {
+    static func setGlobalAttributes(_ attributes: [String:TagValue]) {
+        globalAttributes.write(value: attributes)
+    }
+
+    static func getGlobalAttributes() -> [String:TagValue] {
+        return globalAttributes.read()
+    }
+    
+    static func setSessionId(_ id: String) {
+        sessionId.write(value: id)
+    }
+    
+    static func getSessionId() -> String {
+        return sessionId.read()
+    }
+}

--- a/ios/RWLocked.swift
+++ b/ios/RWLocked.swift
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+class RWLocked<T> {
+    private var lock: pthread_rwlock_t = pthread_rwlock_t()
+    private var guarded: T
+    
+    init(initialValue: T) {
+        pthread_rwlock_init(&lock, nil)
+        self.guarded = initialValue
+    }
+    
+    func read() -> T {
+        pthread_rwlock_rdlock(&lock)
+        defer { pthread_rwlock_unlock(&lock) }
+        return guarded
+    }
+    
+    func with_write_access(block: (inout T) -> Void) -> Void {
+        pthread_rwlock_wrlock(&lock)
+        defer { pthread_rwlock_unlock(&lock) }
+        block(&self.guarded)
+    }
+    
+    func write(value: T) {
+        pthread_rwlock_wrlock(&lock)
+        defer { pthread_rwlock_unlock(&lock) }
+        self.guarded = value
+    }
+}

--- a/ios/SpanDb.swift
+++ b/ios/SpanDb.swift
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 import Foundation
 import SQLite3
 

--- a/ios/SpanOps.swift
+++ b/ios/SpanOps.swift
@@ -1,0 +1,69 @@
+/*
+Copyright 2023 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+fileprivate func randomPart() -> UInt64 {
+    return UInt64.random(in: 1 ... .max)
+}
+
+fileprivate func traceId() -> String {
+    return String(format: "%016llx%016llx", randomPart(), randomPart())
+}
+
+fileprivate func spanId() -> String {
+    return String(format: "%016llx", randomPart())
+}
+
+fileprivate func timestamp() -> UInt64 {
+    return UInt64(Date().timeIntervalSince1970 * 1e6)
+}
+
+
+protocol SpanExporter: AnyObject {
+    func export(_ zipkinSpans: [ZipkinSpan]) -> Bool
+    func export(spans: [Dictionary<String, Any>]) -> Bool
+}
+
+class NoopExporter: SpanExporter {
+    func export(_ zipkinSpans: [ZipkinSpan]) -> Bool {
+        return true
+    }
+    
+    func export(spans: [Dictionary<String, Any>]) -> Bool {
+        return true
+    }
+}
+
+func newSpan(name: String) -> ZipkinSpan {
+    return ZipkinSpan(
+        traceId: traceId(),
+        parentId: nil,
+        id: spanId(),
+        kind: nil,
+        name: name,
+        timestamp: timestamp(),
+        duration: nil,
+        remoteEndpoint: nil,
+        annotations: [],
+        tags: [:]
+    )
+}
+
+func endSpan(exporter: SpanExporter, _ span: ZipkinSpan) {
+    span.duration = timestamp() - span.timestamp
+    _ = exporter.export([span])
+}

--- a/ios/SpanToDiskExporter.swift
+++ b/ios/SpanToDiskExporter.swift
@@ -34,7 +34,7 @@ limitations under the License.
 */
 
 
-class SpanToDiskExporter {
+class SpanToDiskExporter : SpanExporter {
     let db: SpanDb
     let maxFileSizeBytes: Int64
     // Count of spans to insert before checking whether truncation is necessary
@@ -57,12 +57,30 @@ class SpanToDiskExporter {
         }
 
         let zipkinSpans = ZipkinTransform.toZipkinSpans(spans: spans)
+        return export(zipkinSpans)
+    }
+
+    public func export(_ zipkinSpans: [ZipkinSpan]) -> Bool {
+        let globalAttribs = Globals.getGlobalAttributes()
+        let sessionId = Globals.getSessionId()
+
+        for span in zipkinSpans {
+            if span.tags["splunk.rumSessionId"] == nil && !sessionId.isEmpty {
+                span.tags["splunk.rumSessionId"] = TagValue.string(sessionId)
+            }
+
+            for (key, attrib) in globalAttribs {
+                if span.tags[key] == nil {
+                    span.tags[key] = attrib
+                }
+            }
+        }
 
         if !db.store(spans: zipkinSpans) {
             return true
         }
 
-        let inserted = Int64(spans.count)
+        let inserted = Int64(zipkinSpans.count)
         checkpointCounter += inserted
 
         // There might be a case where truncation checkpoint is never reached,

--- a/ios/SplunkOtelReactNative.m
+++ b/ios/SplunkOtelReactNative.m
@@ -28,6 +28,14 @@ RCT_EXTERN_METHOD(export:(NSArray*)spans
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setGlobalAttributes:(NSDictionary*)attributes
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(setSessionId:(NSString*)sessionId
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/ios/SplunkOtelReactNative.swift
+++ b/ios/SplunkOtelReactNative.swift
@@ -56,12 +56,6 @@ class SplunkOtelReactNative: NSObject {
 
     @objc(export:withResolver:withRejecter:)
     func export(spans: Array<Dictionary<String, Any>>, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
-        if Double.random(in: 0.0...1.0) > 0.9 {
-            print("crashing")
-            let x: Int? = nil
-            let f = x!
-            print(f)
-        }
         resolve(spanExporter.export(spans: spans))
     }
     

--- a/ios/SplunkOtelReactNative.swift
+++ b/ios/SplunkOtelReactNative.swift
@@ -14,14 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-fileprivate var spanExporter: SpanToDiskExporter?
+fileprivate var spanExporter: SpanExporter = NoopExporter()
 
 @objc(SplunkOtelReactNative)
 class SplunkOtelReactNative: NSObject {
   private var appStartTime = Date()
   @objc(initialize:withResolver:withRejecter:)
   func initialize(config: Dictionary<String, Any>, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
+      let db = SpanDb()
+      spanExporter = SpanToDiskExporter(spanDb: db)
+      initializeCrashReporting(exporter: spanExporter)
+
       print("Default appStartTime \(appStartTime)")
       do {
           appStartTime = try processStartTime()
@@ -46,9 +49,6 @@ class SplunkOtelReactNative: NSObject {
       var beaconWithAuth = beaconUrl!
       beaconWithAuth += "?auth=" + auth!
 
-      let db = SpanDb()
-      spanExporter = SpanToDiskExporter(spanDb: db)
-
       SpanFromDiskExport.start(spanDb: db, endpoint: beaconWithAuth)
 
       resolve(appStartTime.timeIntervalSince1970 * 1000)
@@ -56,13 +56,41 @@ class SplunkOtelReactNative: NSObject {
 
     @objc(export:withResolver:withRejecter:)
     func export(spans: Array<Dictionary<String, Any>>, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
-        if spanExporter == nil {
-            resolve(false)
-            return
+        if Double.random(in: 0.0...1.0) > 0.9 {
+            print("crashing")
+            let x: Int? = nil
+            let f = x!
+            print(f)
         }
-
-        let exporter = spanExporter!
-        resolve(exporter.export(spans: spans))
+        resolve(spanExporter.export(spans: spans))
+    }
+    
+    @objc(setSessionId:withResolver:withRejecter:)
+    func setSessionId(id: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        Globals.setSessionId(id)
+        updateCrashReportSessionId(id)
+        resolve(true)
+    }
+    
+    @objc(setGlobalAttributes:withResolver:withRejecter:)
+    func setGlobalAttributes(attributes: Dictionary<String, Any>, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        let newAttribs: [String:TagValue] = attributes.compactMapValues { v in
+            switch v {
+            case is String:
+                return TagValue.string(v as! String)
+            case is Bool:
+                return TagValue.bool(v as! Bool)
+            case is Double:
+                return TagValue.double(v as! Double)
+            case is Int:
+                return TagValue.int(v as! Int)
+            default:
+                return nil
+            }
+        }
+        
+        Globals.setGlobalAttributes(newAttribs)
+        resolve(true)
     }
     
     private func processStartTime() throws -> Date {

--- a/splunk-otel-react-native.podspec
+++ b/splunk-otel-react-native.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   s.dependency "DeviceKit", "~> 4.0"
+  s.dependency "PLCrashReporter", "~> 1.11"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/src/globalAttributes.ts
+++ b/src/globalAttributes.ts
@@ -19,6 +19,7 @@ import type { Attributes } from '@opentelemetry/api';
 import type { ResourceAttributes } from '@opentelemetry/resources';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { getSessionId } from './session';
+import { setNativeGlobalAttributes } from '.';
 
 let globalAttributes: Attributes = {};
 
@@ -65,6 +66,7 @@ globalAttributes = {
 //screen.name
 export function setGlobalAttributes(attrs: object) {
   globalAttributes = Object.assign(globalAttributes, attrs);
+  setNativeGlobalAttributes(globalAttributes);
 }
 
 export function getGlobalAttributes(): Attributes {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { NativeModules, Platform } from 'react-native';
+import type { Attributes } from '@opentelemetry/api';
 
 const LINKING_ERROR =
   `The package 'splunk-otel-react-native' doesn't seem to be linked. Make sure: \n\n` +
@@ -56,6 +57,24 @@ export function initializeNativeSdk(
 
 export function exportSpanToNative(span: object): Promise<null> {
   return SplunkOtelReactNative.export(span);
+}
+
+export function setNativeSessionId(id: string): Promise<boolean> {
+  if (Platform.OS === 'ios') {
+    return SplunkOtelReactNative.setSessionId(id);
+  }
+
+  return Promise.resolve(false);
+}
+
+export function setNativeGlobalAttributes(attributes: Attributes): Promise<boolean> {
+  if (Platform.OS === 'ios') {
+    // For some reason React Native mucks with the input argument, destroying the object values.
+    // E.g. { 'os.name': 'iOS' } gets turned into { 'os.name': [Getter/Setter] }
+    return SplunkOtelReactNative.setGlobalAttributes({ ...attributes });
+  }
+
+  return Promise.resolve(false);
 }
 
 // TODO workaround for otel which uses timeOrigin

--- a/src/session.ts
+++ b/src/session.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { RandomIdGenerator } from '@opentelemetry/sdk-trace-base';
 import { AppState } from 'react-native';
 import { trace, diag } from '@opentelemetry/api';
+import { setNativeSessionId } from '.';
 
 const idGenerator = new RandomIdGenerator();
 
@@ -92,6 +93,7 @@ function newSessionId() {
   const previousId = session.id;
   session.startTime = Date.now();
   session.id = idGenerator.generateTraceId();
+  setNativeSessionId(session.id);
   diag.debug('Session:newSessionId:', previousId, session.id);
   const span = tracer.startSpan('sessionId.change', {
     attributes: {

--- a/src/splunkRum.ts
+++ b/src/splunkRum.ts
@@ -30,6 +30,7 @@ import {
   initializeNativeSdk,
   ReactNativeConfiguration,
   NativeSdKConfiguration,
+  setNativeSessionId,
 } from './index';
 import ReacNativeSpanExporter from './exporting';
 import GlobalAttributeAppender from './globalAttributeAppender';
@@ -37,7 +38,7 @@ import { instrumentXHR } from './instrumentations/xhr';
 import { instrumentErrors, reportError } from './instrumentations/errors';
 import { setGlobalAttributes } from './globalAttributes';
 import { LOCATION_LATITUDE, LOCATION_LONGITUDE } from './splunkAttributeNames';
-import { _generatenewSessionId } from './session';
+import { getSessionId, _generatenewSessionId } from './session';
 
 interface SplunkRumType {
   appStart?: Span;
@@ -129,6 +130,7 @@ export const SplunkRum: SplunkRumType = {
     );
 
     initializeNativeSdk(nativeSdkConf).then((appStartTime) => {
+      setNativeSessionId(getSessionId())
       diag.debug(
         'AppStart: native module start',
         appStartTime,


### PR DESCRIPTION
* Use PLCrashReporter directly as the dependency, copied over crash reporting code from splunk-otel-ios-crashreporting.
* Added passing of session ID and global attributes to the native side.
* Added "OTel API" functionality to Zipkin spans 🤢 such as starting and ending spans and adding attributes.