### PR TITLE
fix: ios exporting

### DIFF
--- a/ios/Globals.swift
+++ b/ios/Globals.swift
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-fileprivate var globalAttributes = RWLocked<[String:TagValue]>(initialValue: [:])
+fileprivate var globalAttributes = RWLocked<[String:String]>(initialValue: [:])
 fileprivate var sessionId = RWLocked<String>(initialValue: "")
 
 struct Globals {
-    static func setGlobalAttributes(_ attributes: [String:TagValue]) {
+    static func setGlobalAttributes(_ attributes: [String:String]) {
         globalAttributes.write(value: attributes)
     }
 
-    static func getGlobalAttributes() -> [String:TagValue] {
+    static func getGlobalAttributes() -> [String:String] {
         return globalAttributes.read()
     }
     

--- a/ios/SpanToDiskExporter.swift
+++ b/ios/SpanToDiskExporter.swift
@@ -66,7 +66,7 @@ class SpanToDiskExporter : SpanExporter {
 
         for span in zipkinSpans {
             if span.tags["splunk.rumSessionId"] == nil && !sessionId.isEmpty {
-                span.tags["splunk.rumSessionId"] = TagValue.string(sessionId)
+                span.tags["splunk.rumSessionId"] = sessionId
             }
 
             for (key, attrib) in globalAttribs {

--- a/ios/SplunkOtelReactNative.swift
+++ b/ios/SplunkOtelReactNative.swift
@@ -68,16 +68,16 @@ class SplunkOtelReactNative: NSObject {
     
     @objc(setGlobalAttributes:withResolver:withRejecter:)
     func setGlobalAttributes(attributes: Dictionary<String, Any>, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        let newAttribs: [String:TagValue] = attributes.compactMapValues { v in
+        let newAttribs: [String:String] = attributes.compactMapValues { v in
             switch v {
             case is String:
-                return TagValue.string(v as! String)
+                return v as! String
             case is Bool:
-                return TagValue.bool(v as! Bool)
+                return (v as! Bool).description
             case is Double:
-                return TagValue.double(v as! Double)
+                return (v as! Double).description
             case is Int:
-                return TagValue.int(v as! Int)
+                return (v as! Int).description
             default:
                 return nil
             }


### PR DESCRIPTION
* Zipkin: convert attributes to strings as Zipkin does not allow non-string values
* Set the native session ID before initializing the native SDK, otherwise the `CrashReportInit` span won't have a session ID associated with it