### PR TITLE
Fix crashes not having global attributes set

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "SplunkOtelReactNativeExample",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "SplunkOtelReactNativeExample",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@react-navigation/native": "^6.0.13",
@@ -34,6 +34,7 @@
       }
     },
     "..": {
+      "name": "@splunk/otel-react-native",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/splunkRum.ts
+++ b/src/splunkRum.ts
@@ -161,7 +161,6 @@ export const SplunkRum: SplunkRumType = {
     instrumentErrors();
 
     const nativeInit = Date.now();
-    
 
     diag.debug(
       'Initializing with: ',
@@ -179,7 +178,8 @@ export const SplunkRum: SplunkRumType = {
           appStartInfo.appStart || appStartInfo.moduleStart;
       }
       setNativeSessionId(getSessionId());
-
+      // make sure native crashreporter has correct attributes
+      setGlobalAttributes({});
       if (config.appStartEnabled) {
         const tracer = provider.getTracer('AppStart');
         const nativeInitEnd = Date.now();
@@ -194,12 +194,13 @@ export const SplunkRum: SplunkRumType = {
 
         //FIXME no need to have native init span probably
         const ctx = trace.setSpan(context.active(), this.appStartSpan);
+
         context.with(ctx, () => {
           tracer
-            .startSpan('nativeInit', { startTime: nativeInit })
+            .startSpan('SplunkRum.nativeInit', { startTime: nativeInit })
             .end(nativeInitEnd);
           tracer
-            .startSpan('clientInit', { startTime: clientInit })
+            .startSpan('SplunkRum.jsInit', { startTime: clientInit })
             .end(clientInitEnd);
         });
 


### PR DESCRIPTION
If no navigation library instrumented nothing sets global attributes after native init.