### PR TITLE
DEMRUM-4369: Make `EndpointConfiguration` optional

### DIFF
--- a/example/ios/SplunkOtelReactNativeExample.xcodeproj/project.pbxproj
+++ b/example/ios/SplunkOtelReactNativeExample.xcodeproj/project.pbxproj
@@ -9,9 +9,9 @@
 /* Begin PBXBuildFile section */
 		07DB1233217026F5F68FA3C7 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		2192DBF3388197C65C0B9874 /* Pods_SplunkOtelReactNativeExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 388B902B3B88D3EEDCA64B8C /* Pods_SplunkOtelReactNativeExample.framework */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		BCC9C0756EADB01D017F4ECF /* Pods_SplunkOtelReactNativeExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBD737F712973F9065B373AD /* Pods_SplunkOtelReactNativeExample.framework */; };
 		SPLK0001000000000000001A /* SplunkTestModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = SPLK0001000000000000001B /* SplunkTestModule.swift */; };
 		SPLK0001000000000000002A /* SplunkTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = SPLK0001000000000000002B /* SplunkTestModule.m */; };
 /* End PBXBuildFile section */
@@ -21,11 +21,11 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = SplunkOtelReactNativeExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = SplunkOtelReactNativeExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = SplunkOtelReactNativeExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		388B902B3B88D3EEDCA64B8C /* Pods_SplunkOtelReactNativeExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SplunkOtelReactNativeExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-SplunkOtelReactNativeExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SplunkOtelReactNativeExample.debug.xcconfig"; path = "Target Support Files/Pods-SplunkOtelReactNativeExample/Pods-SplunkOtelReactNativeExample.debug.xcconfig"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-SplunkOtelReactNativeExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SplunkOtelReactNativeExample.release.xcconfig"; path = "Target Support Files/Pods-SplunkOtelReactNativeExample/Pods-SplunkOtelReactNativeExample.release.xcconfig"; sourceTree = "<group>"; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = SplunkOtelReactNativeExample/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = SplunkOtelReactNativeExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		CBD737F712973F9065B373AD /* Pods_SplunkOtelReactNativeExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SplunkOtelReactNativeExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		SPLK0001000000000000001B /* SplunkTestModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SplunkTestModule.swift; path = SplunkOtelReactNativeExample/SplunkTestModule.swift; sourceTree = "<group>"; };
 		SPLK0001000000000000002B /* SplunkTestModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SplunkTestModule.m; path = SplunkOtelReactNativeExample/SplunkTestModule.m; sourceTree = "<group>"; };
@@ -37,7 +37,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCC9C0756EADB01D017F4ECF /* Pods_SplunkOtelReactNativeExample.framework in Frameworks */,
+				2192DBF3388197C65C0B9874 /* Pods_SplunkOtelReactNativeExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,7 +63,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				CBD737F712973F9065B373AD /* Pods_SplunkOtelReactNativeExample.framework */,
+				388B902B3B88D3EEDCA64B8C /* Pods_SplunkOtelReactNativeExample.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/example/ios/SplunkOtelReactNativeExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/SplunkOtelReactNativeExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,39 +2,12 @@
   "originHash" : "cdda925e9f44f43165a91e84476d7303c4a00233e0eaa387e54832e886e2236c",
   "pins" : [
     {
-      "identity" : "datacompression",
+      "identity" : "opentelemetry-swift-core",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mw99/DataCompression",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift-core",
       "state" : {
-        "revision" : "16f858982a077451ce3bdbd9144d3073ec85b6e4",
-        "version" : "3.9.0"
-      }
-    },
-    {
-      "identity" : "grpc-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-swift.git",
-      "state" : {
-        "revision" : "a56a157218877ef3e9625f7e1f7b2cb7e46ead1b",
-        "version" : "1.26.1"
-      }
-    },
-    {
-      "identity" : "opentelemetry-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/open-telemetry/opentelemetry-swift",
-      "state" : {
-        "revision" : "ed2b110d2bb4516e9c73df86c56a7836f5068666",
-        "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "opentracing-objc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/opentracing-objc",
-      "state" : {
-        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
-        "version" : "0.5.2"
+        "revision" : "240c8d5e36c3c7b774ed961325369f0b1f2c965f",
+        "version" : "2.3.0"
       }
     },
     {
@@ -42,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/microsoft/plcrashreporter",
       "state" : {
-        "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
-        "version" : "1.12.2"
+        "revision" : "8c61e5e38e9f737dd68512ed1ea5ab081244ad65",
+        "version" : "1.12.0"
       }
     },
     {
@@ -51,35 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/signalfx/splunk-otel-ios.git",
       "state" : {
-        "revision" : "cb3920ac50ca910d43e2b65c09785e0778c9b3ae",
-        "version" : "2.0.4"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "40d25bbb2fc5b557a9aa8512210bded327c0f60d",
-        "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
-        "version" : "1.0.4"
+        "revision" : "fff2ffecec888fea0290f4ac312704216dc166dc",
+        "version" : "2.2.1"
       }
     },
     {
@@ -89,159 +35,6 @@
       "state" : {
         "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
         "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "c399f90e7bbe8874f6cbfda1d5f9023d1f5ce122",
-        "version" : "1.15.1"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "e8ed8867ec23bccf5f3bb9342148fa8deaff9b49",
-        "version" : "4.1.0"
-      }
-    },
-    {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
-        "version" : "1.6.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
-        "version" : "1.5.1"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swift-metrics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-metrics.git",
-      "state" : {
-        "revision" : "0743a9364382629da3bf5677b46a2c4b1ce5d2a6",
-        "version" : "2.7.1"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "6e02c7a2467cf22526ac54521d4230d8c5890e62",
-        "version" : "2.90.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "7ee281d816fa8e5f3967a2c294035a318ea551c7",
-        "version" : "1.31.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "c2ba4cfbb83f307c66f5a6df6bb43e3c88dfbf80",
-        "version" : "1.39.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
-        "version" : "2.36.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "df6c28355051c72c884574a6c858bc54f7311ff9",
-        "version" : "1.25.2"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "c169a5744230951031770e27e475ff6eefe51f9d",
-        "version" : "1.33.3"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "1de37290c0ab3c5a96028e0f02911b672fd42348",
-        "version" : "2.9.1"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
-        "version" : "1.6.3"
-      }
-    },
-    {
-      "identity" : "thrift-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
-      "state" : {
-        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
-        "version" : "1.1.2"
       }
     }
   ],

--- a/example/src/ApiAssertions.ts
+++ b/example/src/ApiAssertions.ts
@@ -229,6 +229,31 @@ export async function runApiAssertionTests(): Promise<ApiTestReport> {
       'size should be 0 after removeAll()'
     );
 
+    console.log('[API Test] Testing Endpoint Preferences...');
+
+    // Verify preferences API exists
+    assertions.assert(
+      sdk.preferences !== undefined && sdk.preferences !== null,
+      'Preferences',
+      'preferences object should be available'
+    );
+
+    assertions.assert(
+      typeof sdk.preferences.setEndpointConfiguration === 'function',
+      'Preferences',
+      'setEndpointConfiguration should be a function'
+    );
+
+    // Read current endpoint from state
+    const currentEndpoint = state.endpoint;
+    assertions.assert(
+      currentEndpoint === undefined ||
+        ('realm' in currentEndpoint && currentEndpoint.realm.length > 0) ||
+        ('trace' in currentEndpoint && currentEndpoint.trace.length > 0),
+      'Preferences',
+      `endpoint should be undefined or have valid config (got: ${JSON.stringify(currentEndpoint)})`
+    );
+
     console.log('[API Test] Testing Custom Tracking...');
 
     // Track event - should not throw

--- a/example/src/components/TestActionsComponent.tsx
+++ b/example/src/components/TestActionsComponent.tsx
@@ -20,6 +20,7 @@ export const TestActionsComponent: React.FC<TestActionsComponentProps> = ({
       [TestCategory.Network]: [],
       [TestCategory.Session]: [],
       [TestCategory.GlobalAttributes]: [],
+      [TestCategory.EndpointConfiguration]: [],
       [TestCategory.ApiTests]: [],
     };
 
@@ -38,6 +39,7 @@ export const TestActionsComponent: React.FC<TestActionsComponentProps> = ({
     TestCategory.Navigation,
     TestCategory.CustomTracking,
     TestCategory.Session,
+    TestCategory.EndpointConfiguration,
     TestCategory.GlobalAttributes,
   ];
 

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -12,7 +12,8 @@ import {
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { SplunkRum } from '@splunk/otel-react-native';
+import { SplunkRum, type EndpointConfiguration } from '@splunk/otel-react-native';
+import { config as appConfig } from '../config';
 
 import { TestCategory, MobilePlatform, type TestAction } from '../types';
 import { TestActionsWidget, StatusBar } from '../components';
@@ -320,6 +321,76 @@ export const HomeScreen: React.FC<Props> = ({ navigation, installed }) => {
           );
           const user = await SplunkRum.instance.user.state();
           Alert.alert('User Tracking', `Mode set to: ${user.trackingMode}`);
+        },
+      },
+
+      // Endpoint Configuration
+      {
+        id: 'endpoint-set-realm',
+        title: 'Set Endpoint (Realm)',
+        description: 'Configure endpoint using realm via preferences',
+        category: TestCategory.EndpointConfiguration,
+        platforms: new Set([MobilePlatform.Android, MobilePlatform.iOS]),
+        onTap: async () => {
+          const endpoint: EndpointConfiguration = {
+            realm: appConfig.realm,
+            rumAccessToken: appConfig.rumAccessToken,
+          };
+          await SplunkRum.instance.preferences.setEndpointConfiguration(
+            endpoint
+          );
+          Alert.alert(
+            'Endpoint Set',
+            `Realm: ${appConfig.realm}\nData will now be sent.`
+          );
+        },
+      },
+      {
+        id: 'endpoint-set-custom',
+        title: 'Set Endpoint (Custom URL)',
+        description: 'Configure endpoint using custom trace URL',
+        category: TestCategory.EndpointConfiguration,
+        platforms: new Set([MobilePlatform.Android, MobilePlatform.iOS]),
+        onTap: async () => {
+          await SplunkRum.instance.preferences.setEndpointConfiguration({
+            trace: 'https://custom-collector.example.com/v1/traces',
+          });
+          Alert.alert('Endpoint Set', 'Custom trace URL configured.');
+        },
+      },
+      {
+        id: 'endpoint-clear',
+        title: 'Clear Endpoint',
+        description: 'Clear the endpoint to stop sending data',
+        category: TestCategory.EndpointConfiguration,
+        platforms: new Set([MobilePlatform.Android, MobilePlatform.iOS]),
+        onTap: async () => {
+          await SplunkRum.instance.preferences.setEndpointConfiguration(null);
+          Alert.alert('Endpoint Cleared', 'Data will be buffered locally.');
+        },
+      },
+      {
+        id: 'endpoint-check-state',
+        title: 'Check Endpoint State',
+        description: 'Read current endpoint from agent state',
+        category: TestCategory.EndpointConfiguration,
+        platforms: new Set([MobilePlatform.Android, MobilePlatform.iOS]),
+        onTap: async () => {
+          const state = await SplunkRum.instance.getState();
+          const ep = state.endpoint;
+          if (!ep) {
+            Alert.alert('Endpoint State', 'No endpoint configured.');
+          } else if ('realm' in ep) {
+            Alert.alert(
+              'Endpoint State',
+              `Realm: ${ep.realm}\nToken: ${ep.rumAccessToken.substring(0, 8)}...`
+            );
+          } else {
+            Alert.alert(
+              'Endpoint State',
+              `Trace: ${ep.trace}\nReplay: ${ep.sessionReplay ?? 'none'}`
+            );
+          }
         },
       },
 

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -12,7 +12,10 @@ import {
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { SplunkRum, type EndpointConfiguration } from '@splunk/otel-react-native';
+import {
+  SplunkRum,
+  type EndpointConfiguration,
+} from '@splunk/otel-react-native';
 import { config as appConfig } from '../config';
 
 import { TestCategory, MobilePlatform, type TestAction } from '../types';

--- a/example/src/types.ts
+++ b/example/src/types.ts
@@ -7,6 +7,7 @@ export enum TestCategory {
   Network = 'network',
   Session = 'session',
   GlobalAttributes = 'globalAttributes',
+  EndpointConfiguration = 'endpointConfiguration',
   ApiTests = 'apiTests',
 }
 
@@ -46,5 +47,6 @@ export const categoryLabels: Record<TestCategory, string> = {
   [TestCategory.Network]: 'Network',
   [TestCategory.Session]: 'Session',
   [TestCategory.GlobalAttributes]: 'Global Attributes',
+  [TestCategory.EndpointConfiguration]: 'Endpoint Configuration',
   [TestCategory.ApiTests]: 'API Tests',
 };

--- a/packages/core/android/src/main/kotlin/com/splunk/otel/reactnative/AgentConfigurationBuilder.kt
+++ b/packages/core/android/src/main/kotlin/com/splunk/otel/reactnative/AgentConfigurationBuilder.kt
@@ -28,12 +28,8 @@ import java.net.URL
  */
 object AgentConfigurationBuilder {
 
-  fun build(map: ReadableMap): AgentConfiguration {
-    val endpointMapAny = map.getMap("endpoint")
-      ?: throw IllegalArgumentException("endpoint is required")
-    val endpointMap = endpointMapAny as ReadableMap
-
-    val endpoint = if (endpointMap.hasKey("realm")) {
+  fun buildEndpoint(endpointMap: ReadableMap): EndpointConfiguration {
+    return if (endpointMap.hasKey("realm")) {
       EndpointConfiguration(endpointMap.getString("realm")!!, endpointMap.getString("rumAccessToken")!!)
     } else if (endpointMap.hasKey("trace")) {
       val traceStr = endpointMap.getString("trace")
@@ -46,6 +42,14 @@ object AgentConfigurationBuilder {
       if (sr != null) EndpointConfiguration(trace, sr) else EndpointConfiguration(trace)
     } else {
       throw IllegalArgumentException("endpoint must specify either realm/rumAccessToken or trace")
+    }
+  }
+
+  fun build(map: ReadableMap): AgentConfiguration {
+    val endpoint = if (map.hasKey("endpoint") && !map.isNull("endpoint")) {
+      buildEndpoint(map.getMap("endpoint")!!)
+    } else {
+      null
     }
 
     val appName = map.getString("appName") ?: ""

--- a/packages/core/android/src/main/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeImplementation.kt
+++ b/packages/core/android/src/main/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeImplementation.kt
@@ -52,6 +52,19 @@ class SplunkOtelReactNativeImplementation(private val reactContext: ReactApplica
     }
   }
 
+  // MARK: - Preferences
+
+  fun setEndpointConfiguration(endpoint: ReadableMap?, promise: Promise) {
+    try {
+      val config = endpoint?.let { AgentConfigurationBuilder.buildEndpoint(it) }
+      SplunkRum.instance.preferences.endpointConfiguration = config
+      promise.resolve(null)
+    } catch (t: Throwable) {
+      Log.e(TAG, "setEndpointConfiguration() - failed", t)
+      promise.reject("E_SET_ENDPOINT", t)
+    }
+  }
+
   companion object {
     private const val TAG = "SplunkOtelRN"
     const val NAME = "SplunkOtelReactNative"

--- a/packages/core/android/src/main/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeImplementation.kt
+++ b/packages/core/android/src/main/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeImplementation.kt
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.bridge.WritableNativeMap
 import com.splunk.rum.integration.agent.api.SplunkRum
 import com.splunk.rum.integration.navigation.extension.navigation
 
@@ -54,13 +55,44 @@ class SplunkOtelReactNativeImplementation(private val reactContext: ReactApplica
 
   // MARK: - Preferences
 
+  fun getEndpointConfiguration(promise: Promise) {
+    try {
+      val ep = SplunkRum.instance.preferences.endpointConfiguration
+      
+      if (ep != null) {
+        val map = WritableNativeMap()
+
+        if (ep.realm != null) {
+          map.putString("realm", ep.realm)
+          map.putString("rumAccessToken", ep.rumAccessToken)
+        } else {
+          map.putString("trace", ep.traceEndpoint.toString())
+
+          if (ep.sessionReplayEndpoint != null) {
+            map.putString("sessionReplay", ep.sessionReplayEndpoint.toString())
+          }
+        }
+
+        promise.resolve(map)
+      } else {
+        promise.resolve(null)
+      }
+    } catch (t: Throwable) {
+      Log.e(TAG, "getEndpointConfiguration() - failed", t)
+
+      promise.reject("E_GET_ENDPOINT", t)
+    }
+  }
+
   fun setEndpointConfiguration(endpoint: ReadableMap?, promise: Promise) {
     try {
       val config = endpoint?.let { AgentConfigurationBuilder.buildEndpoint(it) }
       SplunkRum.instance.preferences.endpointConfiguration = config
+
       promise.resolve(null)
     } catch (t: Throwable) {
       Log.e(TAG, "setEndpointConfiguration() - failed", t)
+
       promise.reject("E_SET_ENDPOINT", t)
     }
   }

--- a/packages/core/android/src/main/kotlin/com/splunk/otel/reactnative/StateSerializer.kt
+++ b/packages/core/android/src/main/kotlin/com/splunk/otel/reactnative/StateSerializer.kt
@@ -51,17 +51,22 @@ object StateSerializer {
 
     map.putMap("status", statusMap)
 
-    val endpointMap = WritableNativeMap()
     val ep = state.endpointConfiguration
-
-    if (ep?.realm != null) {
-      endpointMap.putString("realm", ep.realm)
-      endpointMap.putString("rumAccessToken", ep.rumAccessToken)
+    if (ep != null) {
+      val endpointMap = WritableNativeMap()
+      if (ep.realm != null) {
+        endpointMap.putString("realm", ep.realm)
+        endpointMap.putString("rumAccessToken", ep.rumAccessToken)
+      } else {
+        endpointMap.putString("trace", ep.traceEndpoint.toString())
+        if (ep.sessionReplayEndpoint != null) {
+          endpointMap.putString("sessionReplay", ep.sessionReplayEndpoint.toString())
+        }
+      }
+      map.putMap("endpoint", endpointMap)
     } else {
-      endpointMap.putString("trace", ep?.traceEndpoint?.toString())
-      if (ep?.sessionReplayEndpoint != null) endpointMap.putString("sessionReplay", ep.sessionReplayEndpoint.toString())
+      map.putNull("endpoint")
     }
-    map.putMap("endpoint", endpointMap)
 
     return map
   }

--- a/packages/core/android/src/newarch/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeModule.kt
+++ b/packages/core/android/src/newarch/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeModule.kt
@@ -33,6 +33,9 @@ class SplunkOtelReactNativeModule(reactContext: ReactApplicationContext) :
   override fun install(configuration: ReadableMap, modules: ReadableArray, promise: Promise) =
     implementation.install(configuration, modules, promise)
 
+  override fun getEndpointConfiguration(promise: Promise) =
+    implementation.getEndpointConfiguration(promise)
+
   override fun setEndpointConfiguration(endpoint: ReadableMap?, promise: Promise) =
     implementation.setEndpointConfiguration(endpoint, promise)
 

--- a/packages/core/android/src/newarch/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeModule.kt
+++ b/packages/core/android/src/newarch/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeModule.kt
@@ -33,6 +33,9 @@ class SplunkOtelReactNativeModule(reactContext: ReactApplicationContext) :
   override fun install(configuration: ReadableMap, modules: ReadableArray, promise: Promise) =
     implementation.install(configuration, modules, promise)
 
+  override fun setEndpointConfiguration(endpoint: ReadableMap?, promise: Promise) =
+    implementation.setEndpointConfiguration(endpoint, promise)
+
   override fun getState(promise: Promise) = implementation.getState(promise)
 
   override fun getSessionState(promise: Promise) = implementation.getSessionState(promise)

--- a/packages/core/android/src/oldarch/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeModule.kt
+++ b/packages/core/android/src/oldarch/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeModule.kt
@@ -37,6 +37,10 @@ class SplunkOtelReactNativeModule(reactContext: ReactApplicationContext) :
     implementation.install(configuration, modules, promise)
 
   @ReactMethod
+  fun getEndpointConfiguration(promise: Promise) =
+    implementation.getEndpointConfiguration(promise)
+
+  @ReactMethod
   fun setEndpointConfiguration(endpoint: ReadableMap?, promise: Promise) =
     implementation.setEndpointConfiguration(endpoint, promise)
 

--- a/packages/core/android/src/oldarch/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeModule.kt
+++ b/packages/core/android/src/oldarch/kotlin/com/splunk/otel/reactnative/SplunkOtelReactNativeModule.kt
@@ -37,6 +37,10 @@ class SplunkOtelReactNativeModule(reactContext: ReactApplicationContext) :
     implementation.install(configuration, modules, promise)
 
   @ReactMethod
+  fun setEndpointConfiguration(endpoint: ReadableMap?, promise: Promise) =
+    implementation.setEndpointConfiguration(endpoint, promise)
+
+  @ReactMethod
   fun getState(promise: Promise) = implementation.getState(promise)
 
   @ReactMethod

--- a/packages/core/ios/AgentConfigurationBuilder.swift
+++ b/packages/core/ios/AgentConfigurationBuilder.swift
@@ -21,10 +21,12 @@ import SplunkAgent
 enum AgentConfigurationBuilder {
 
   static func build(from dict: NSDictionary) throws -> AgentConfiguration {
-    guard let endpointAny = dict.object(forKey: "endpoint"), !(endpointAny is NSNull) else {
-      throw NSError(domain: "splunk.rn", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing endpoint in configuration"])
+    let endpoint: EndpointConfiguration?
+    if let endpointAny = dict.object(forKey: "endpoint"), !(endpointAny is NSNull) {
+      endpoint = try buildEndpoint(from: endpointAny as? NSDictionary ?? NSDictionary())
+    } else {
+      endpoint = nil
     }
-    let endpoint = try buildEndpoint(from: endpointAny as? NSDictionary ?? NSDictionary())
 
     guard let appName = dict.object(forKey: "appName") as? String,
           let env = dict.object(forKey: "deploymentEnvironment") as? String else {

--- a/packages/core/ios/SplunkOtelReactNative.h
+++ b/packages/core/ios/SplunkOtelReactNative.h
@@ -37,6 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
         resolve:(RCTPromiseResolveBlock)resolve
          reject:(RCTPromiseRejectBlock)reject;
 
+// Preferences
+- (void)setEndpointConfiguration:(nullable NSDictionary *)endpoint
+                         resolve:(RCTPromiseResolveBlock)resolve
+                          reject:(RCTPromiseRejectBlock)reject;
+
 // State
 - (void)getState:(RCTPromiseResolveBlock)resolve
           reject:(RCTPromiseRejectBlock)reject;

--- a/packages/core/ios/SplunkOtelReactNative.h
+++ b/packages/core/ios/SplunkOtelReactNative.h
@@ -38,6 +38,9 @@ NS_ASSUME_NONNULL_BEGIN
          reject:(RCTPromiseRejectBlock)reject;
 
 // Preferences
+- (void)getEndpointConfiguration:(RCTPromiseResolveBlock)resolve
+                          reject:(RCTPromiseRejectBlock)reject;
+
 - (void)setEndpointConfiguration:(nullable NSDictionary *)endpoint
                          resolve:(RCTPromiseResolveBlock)resolve
                           reject:(RCTPromiseRejectBlock)reject;

--- a/packages/core/ios/SplunkOtelReactNative.mm
+++ b/packages/core/ios/SplunkOtelReactNative.mm
@@ -120,6 +120,21 @@ RCT_EXPORT_METHOD(install:(NSDictionary *)configuration
 #pragma mark - Preferences
 
 #ifndef RCT_NEW_ARCH_ENABLED
+RCT_REMAP_METHOD(getEndpointConfiguration,
+                 getEndpointConfigurationWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [self getEndpointConfiguration:resolve reject:reject];
+}
+#endif
+
+- (void)getEndpointConfiguration:(RCTPromiseResolveBlock)resolve
+                          reject:(RCTPromiseRejectBlock)reject
+{
+  [self.impl getEndpointConfiguration:resolve reject:reject];
+}
+
+#ifndef RCT_NEW_ARCH_ENABLED
 RCT_REMAP_METHOD(setEndpointConfiguration,
                  setEndpointConfigurationEndpoint:(nullable NSDictionary *)endpoint
                  resolver:(RCTPromiseResolveBlock)resolve

--- a/packages/core/ios/SplunkOtelReactNative.mm
+++ b/packages/core/ios/SplunkOtelReactNative.mm
@@ -117,6 +117,25 @@ RCT_EXPORT_METHOD(install:(NSDictionary *)configuration
   [self installWithConfiguration:configuration modules:modules resolve:resolve reject:reject];
 }
 
+#pragma mark - Preferences
+
+#ifndef RCT_NEW_ARCH_ENABLED
+RCT_REMAP_METHOD(setEndpointConfiguration,
+                 setEndpointConfigurationEndpoint:(nullable NSDictionary *)endpoint
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [self setEndpointConfiguration:endpoint resolve:resolve reject:reject];
+}
+#endif
+
+- (void)setEndpointConfiguration:(nullable NSDictionary *)endpoint
+                         resolve:(RCTPromiseResolveBlock)resolve
+                          reject:(RCTPromiseRejectBlock)reject
+{
+  [self.impl setEndpointConfiguration:endpoint resolve:resolve reject:reject];
+}
+
 #pragma mark - State / Session / User
 
 #ifndef RCT_NEW_ARCH_ENABLED

--- a/packages/core/ios/SplunkOtelReactNativeImplementation.swift
+++ b/packages/core/ios/SplunkOtelReactNativeImplementation.swift
@@ -59,6 +59,15 @@ public class SplunkOtelReactNativeImplementation: NSObject {
   // MARK: - Preferences
 
   @objc
+  public func getEndpointConfiguration(_ resolve: @escaping RCTPromiseResolveBlock,
+                                        reject: @escaping RCTPromiseRejectBlock) {
+    let ep = SplunkRum.shared.preferences.endpointConfiguration
+    let serialized = StateSerializer.serializeEndpoint(ep)
+
+    resolve(serialized is NSNull ? nil : serialized)
+  }
+
+  @objc
   public func setEndpointConfiguration(_ endpoint: NSDictionary?,
                                         resolve: @escaping RCTPromiseResolveBlock,
                                         reject: @escaping RCTPromiseRejectBlock) {

--- a/packages/core/ios/SplunkOtelReactNativeImplementation.swift
+++ b/packages/core/ios/SplunkOtelReactNativeImplementation.swift
@@ -56,6 +56,25 @@ public class SplunkOtelReactNativeImplementation: NSObject {
     }
   }
 
+  // MARK: - Preferences
+
+  @objc
+  public func setEndpointConfiguration(_ endpoint: NSDictionary?,
+                                        resolve: @escaping RCTPromiseResolveBlock,
+                                        reject: @escaping RCTPromiseRejectBlock) {
+    do {
+      if let endpointDict = endpoint, !(endpointDict is NSNull) {
+        let config = try AgentConfigurationBuilder.buildEndpoint(from: endpointDict)
+        SplunkRum.shared.preferences.endpointConfiguration = config
+      } else {
+        SplunkRum.shared.preferences.endpointConfiguration = nil
+      }
+      resolve(nil)
+    } catch {
+      reject("set_endpoint_error", "\(error)", error)
+    }
+  }
+
   // MARK: - State / Session / User
 
   @objc

--- a/packages/core/ios/StateSerializer.swift
+++ b/packages/core/ios/StateSerializer.swift
@@ -50,7 +50,9 @@ enum StateSerializer {
     ]
   }
 
-  static func serializeEndpoint(_ ep: EndpointConfiguration) -> [String: Any] {
+  static func serializeEndpoint(_ ep: EndpointConfiguration?) -> Any {
+    guard let ep = ep else { return NSNull() }
+
     if let realm = ep.realm, let token = ep.rumAccessToken {
       return ["realm": realm, "rumAccessToken": token]
     }

--- a/packages/core/jest/mock.js
+++ b/packages/core/jest/mock.js
@@ -90,7 +90,12 @@ const navigationMock = {
   track: jest.fn().mockResolvedValue(undefined),
 };
 
+const agentPreferencesMock = {
+  setEndpointConfiguration: jest.fn().mockResolvedValue(undefined),
+};
+
 const splunkRumInstanceMock = {
+  preferences: agentPreferencesMock,
   globalAttributes: globalAttributesMock,
   session: sessionMock,
   user: userMock,
@@ -273,10 +278,17 @@ class MutableAttributesMock {
   }
 }
 
+class AgentPreferencesMock {
+  constructor() {
+    this.setEndpointConfiguration = jest.fn().mockResolvedValue(undefined);
+  }
+}
+
 module.exports = {
   SplunkRum: SplunkRumMock,
   SplunkRumProvider: SplunkRumProviderMock,
   SplunkWebView: SplunkWebViewMock,
+  AgentPreferences: AgentPreferencesMock,
   ModuleConfiguration: ModuleConfigurationMock,
   AnrModuleConfiguration: createModuleConfigMock('anr'),
   ApplicationLifecycleModuleConfiguration: createModuleConfigMock(

--- a/packages/core/jest/mock.js
+++ b/packages/core/jest/mock.js
@@ -91,6 +91,7 @@ const navigationMock = {
 };
 
 const agentPreferencesMock = {
+  getEndpointConfiguration: jest.fn().mockResolvedValue(undefined),
   setEndpointConfiguration: jest.fn().mockResolvedValue(undefined),
 };
 
@@ -280,6 +281,7 @@ class MutableAttributesMock {
 
 class AgentPreferencesMock {
   constructor() {
+    this.getEndpointConfiguration = jest.fn().mockResolvedValue(undefined);
     this.setEndpointConfiguration = jest.fn().mockResolvedValue(undefined);
   }
 }

--- a/packages/core/src/__tests__/agentPreferences.test.ts
+++ b/packages/core/src/__tests__/agentPreferences.test.ts
@@ -16,10 +16,13 @@
 
 import { AgentPreferences } from '../api/AgentPreferences';
 
+const mockGetEndpointConfiguration = jest.fn().mockResolvedValue(null);
 const mockSetEndpointConfiguration = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../sdk/SplunkNativeBridge', () => ({
   SplunkNativeBridge: {
+    getEndpointConfiguration: (...args: unknown[]) =>
+      mockGetEndpointConfiguration(...args),
     setEndpointConfiguration: (...args: unknown[]) =>
       mockSetEndpointConfiguration(...args),
   },
@@ -30,46 +33,96 @@ describe('AgentPreferences', () => {
 
   beforeEach(() => {
     preferences = new AgentPreferences();
+
+    mockGetEndpointConfiguration.mockClear();
     mockSetEndpointConfiguration.mockClear();
   });
 
-  it('calls native bridge with realm endpoint', async () => {
-    await preferences.setEndpointConfiguration({
-      realm: 'us0',
-      rumAccessToken: 'my-token',
+  describe('getEndpointConfiguration', () => {
+    it('returns undefined when native returns null', async () => {
+      mockGetEndpointConfiguration.mockResolvedValue(null);
+
+      const result = await preferences.getEndpointConfiguration();
+
+      expect(result).toBeUndefined();
+      expect(mockGetEndpointConfiguration).toHaveBeenCalled();
     });
 
-    expect(mockSetEndpointConfiguration).toHaveBeenCalledWith({
-      realm: 'us0',
-      rumAccessToken: 'my-token',
+    it('converts realm endpoint from native', async () => {
+      mockGetEndpointConfiguration.mockResolvedValue({
+        realm: 'us0',
+        rumAccessToken: 'tok',
+      });
+
+      const result = await preferences.getEndpointConfiguration();
+
+      expect(result).toEqual({ realm: 'us0', rumAccessToken: 'tok' });
+    });
+
+    it('converts trace endpoint from native', async () => {
+      mockGetEndpointConfiguration.mockResolvedValue({
+        trace: 'https://t.example.com',
+        sessionReplay: 'https://sr.example.com',
+      });
+
+      const result = await preferences.getEndpointConfiguration();
+
+      expect(result).toEqual({
+        trace: 'https://t.example.com',
+        sessionReplay: 'https://sr.example.com',
+      });
+    });
+
+    it('converts trace-only endpoint from native', async () => {
+      mockGetEndpointConfiguration.mockResolvedValue({
+        trace: 'https://t.example.com',
+      });
+
+      const result = await preferences.getEndpointConfiguration();
+
+      expect(result).toEqual({ trace: 'https://t.example.com' });
     });
   });
 
-  it('calls native bridge with custom trace endpoint', async () => {
-    await preferences.setEndpointConfiguration({
-      trace: 'https://traces.example.com',
-      sessionReplay: 'https://logs.example.com',
+  describe('setEndpointConfiguration', () => {
+    it('calls native bridge with realm endpoint', async () => {
+      await preferences.setEndpointConfiguration({
+        realm: 'us0',
+        rumAccessToken: 'my-token',
+      });
+
+      expect(mockSetEndpointConfiguration).toHaveBeenCalledWith({
+        realm: 'us0',
+        rumAccessToken: 'my-token',
+      });
     });
 
-    expect(mockSetEndpointConfiguration).toHaveBeenCalledWith({
-      trace: 'https://traces.example.com',
-      sessionReplay: 'https://logs.example.com',
+    it('calls native bridge with custom trace endpoint', async () => {
+      await preferences.setEndpointConfiguration({
+        trace: 'https://traces.example.com',
+        sessionReplay: 'https://logs.example.com',
+      });
+
+      expect(mockSetEndpointConfiguration).toHaveBeenCalledWith({
+        trace: 'https://traces.example.com',
+        sessionReplay: 'https://logs.example.com',
+      });
     });
-  });
 
-  it('calls native bridge with trace-only endpoint', async () => {
-    await preferences.setEndpointConfiguration({
-      trace: 'https://traces.example.com',
+    it('calls native bridge with trace-only endpoint', async () => {
+      await preferences.setEndpointConfiguration({
+        trace: 'https://traces.example.com',
+      });
+
+      expect(mockSetEndpointConfiguration).toHaveBeenCalledWith({
+        trace: 'https://traces.example.com',
+      });
     });
 
-    expect(mockSetEndpointConfiguration).toHaveBeenCalledWith({
-      trace: 'https://traces.example.com',
+    it('calls native bridge with null to clear endpoint', async () => {
+      await preferences.setEndpointConfiguration(null);
+
+      expect(mockSetEndpointConfiguration).toHaveBeenCalledWith(null);
     });
-  });
-
-  it('calls native bridge with null to clear endpoint', async () => {
-    await preferences.setEndpointConfiguration(null);
-
-    expect(mockSetEndpointConfiguration).toHaveBeenCalledWith(null);
   });
 });

--- a/packages/core/src/__tests__/agentPreferences.test.ts
+++ b/packages/core/src/__tests__/agentPreferences.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AgentPreferences } from '../api/AgentPreferences';
+
+const mockSetEndpointConfiguration = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../sdk/SplunkNativeBridge', () => ({
+  SplunkNativeBridge: {
+    setEndpointConfiguration: (...args: unknown[]) =>
+      mockSetEndpointConfiguration(...args),
+  },
+}));
+
+describe('AgentPreferences', () => {
+  let preferences: AgentPreferences;
+
+  beforeEach(() => {
+    preferences = new AgentPreferences();
+    mockSetEndpointConfiguration.mockClear();
+  });
+
+  it('calls native bridge with realm endpoint', async () => {
+    await preferences.setEndpointConfiguration({
+      realm: 'us0',
+      rumAccessToken: 'my-token',
+    });
+
+    expect(mockSetEndpointConfiguration).toHaveBeenCalledWith({
+      realm: 'us0',
+      rumAccessToken: 'my-token',
+    });
+  });
+
+  it('calls native bridge with custom trace endpoint', async () => {
+    await preferences.setEndpointConfiguration({
+      trace: 'https://traces.example.com',
+      sessionReplay: 'https://logs.example.com',
+    });
+
+    expect(mockSetEndpointConfiguration).toHaveBeenCalledWith({
+      trace: 'https://traces.example.com',
+      sessionReplay: 'https://logs.example.com',
+    });
+  });
+
+  it('calls native bridge with trace-only endpoint', async () => {
+    await preferences.setEndpointConfiguration({
+      trace: 'https://traces.example.com',
+    });
+
+    expect(mockSetEndpointConfiguration).toHaveBeenCalledWith({
+      trace: 'https://traces.example.com',
+    });
+  });
+
+  it('calls native bridge with null to clear endpoint', async () => {
+    await preferences.setEndpointConfiguration(null);
+
+    expect(mockSetEndpointConfiguration).toHaveBeenCalledWith(null);
+  });
+});

--- a/packages/core/src/__tests__/converters.test.ts
+++ b/packages/core/src/__tests__/converters.test.ts
@@ -18,52 +18,178 @@ import {
   toNativeEndpoint,
   toNativeAgentConfiguration,
   fromNativeState,
+  fromNativeEndpoint,
 } from '../bridge/converters';
 import type { NativeState } from '../specs/NativeSplunkOtelReactNative';
 
 describe('bridge/converters', () => {
-  it('toNativeEndpoint maps realm endpoints', () => {
-    const native = toNativeEndpoint({ realm: 'prod', rumAccessToken: 'token' });
+  describe('toNativeEndpoint', () => {
+    it('maps realm endpoints', () => {
+      const native = toNativeEndpoint({
+        realm: 'prod',
+        rumAccessToken: 'token',
+      });
 
-    expect(native).toEqual({ realm: 'prod', rumAccessToken: 'token' });
-  });
-
-  it('toNativeEndpoint maps ingestion endpoints', () => {
-    const native = toNativeEndpoint({ trace: 't', sessionReplay: 'l' });
-
-    expect(native).toEqual({ trace: 't', sessionReplay: 'l' });
-  });
-
-  it('toNativeAgentConfiguration maps booleans and optionals', () => {
-    const cfg = toNativeAgentConfiguration({
-      endpoint: { trace: 't' },
-      appName: 'app',
-      deploymentEnvironment: 'prod',
-      enableDebugLogging: true,
+      expect(native).toEqual({ realm: 'prod', rumAccessToken: 'token' });
     });
 
-    expect(cfg.appName).toBe('app');
-    expect(cfg.deploymentEnvironment).toBe('prod');
-    expect(cfg.appVersion).toBeNull();
-    expect(cfg.enableDebugLogging).toBe(true);
-    expect(cfg.session.samplingRate).toBe(1);
+    it('maps ingestion endpoints', () => {
+      const native = toNativeEndpoint({ trace: 't', sessionReplay: 'l' });
+
+      expect(native).toEqual({ trace: 't', sessionReplay: 'l' });
+    });
   });
 
-  it('fromNativeState maps status and endpoint', () => {
-    const native: NativeState = {
-      appName: 'a',
-      appVersion: '1.0',
-      deploymentEnvironment: 'prod',
-      status: { type: 'NotRunning', reason: 'NotInstalled' },
-      endpoint: { trace: 't' },
-      isDebugLoggingEnabled: false,
-      instrumentedProcessName: null,
-      deferredUntilForeground: false,
-    };
+  describe('toNativeAgentConfiguration', () => {
+    it('maps booleans and optionals', () => {
+      const cfg = toNativeAgentConfiguration({
+        endpoint: { trace: 't' },
+        appName: 'app',
+        deploymentEnvironment: 'prod',
+        enableDebugLogging: true,
+      });
 
-    const state = fromNativeState(native);
+      expect(cfg.appName).toBe('app');
+      expect(cfg.deploymentEnvironment).toBe('prod');
+      expect(cfg.appVersion).toBeNull();
+      expect(cfg.enableDebugLogging).toBe(true);
+      expect(cfg.session.samplingRate).toBe(1);
+      expect(cfg.endpoint).toEqual({ trace: 't' });
+    });
 
-    expect(state.status.type).toBe('NotRunning');
-    expect(state.endpoint).toEqual({ trace: 't' });
+    it('passes null endpoint when endpoint is omitted', () => {
+      const cfg = toNativeAgentConfiguration({
+        appName: 'app',
+        deploymentEnvironment: 'prod',
+      });
+
+      expect(cfg.endpoint).toBeNull();
+      expect(cfg.appName).toBe('app');
+    });
+
+    it('passes null endpoint when endpoint is undefined', () => {
+      const cfg = toNativeAgentConfiguration({
+        endpoint: undefined,
+        appName: 'app',
+        deploymentEnvironment: 'prod',
+      });
+
+      expect(cfg.endpoint).toBeNull();
+    });
+
+    it('maps realm endpoint when provided', () => {
+      const cfg = toNativeAgentConfiguration({
+        endpoint: { realm: 'us0', rumAccessToken: 'tok' },
+        appName: 'app',
+        deploymentEnvironment: 'prod',
+      });
+
+      expect(cfg.endpoint).toEqual({ realm: 'us0', rumAccessToken: 'tok' });
+    });
+  });
+
+  describe('fromNativeEndpoint', () => {
+    it('returns undefined for null', () => {
+      expect(fromNativeEndpoint(null)).toBeUndefined();
+    });
+
+    it('returns undefined for undefined', () => {
+      expect(fromNativeEndpoint(undefined)).toBeUndefined();
+    });
+
+    it('maps realm endpoint', () => {
+      expect(
+        fromNativeEndpoint({ realm: 'us0', rumAccessToken: 'tok' })
+      ).toEqual({
+        realm: 'us0',
+        rumAccessToken: 'tok',
+      });
+    });
+
+    it('maps trace endpoint', () => {
+      expect(fromNativeEndpoint({ trace: 'https://t.example.com' })).toEqual({
+        trace: 'https://t.example.com',
+      });
+    });
+
+    it('maps trace endpoint with sessionReplay', () => {
+      expect(
+        fromNativeEndpoint({
+          trace: 'https://t.example.com',
+          sessionReplay: 'https://sr.example.com',
+        })
+      ).toEqual({
+        trace: 'https://t.example.com',
+        sessionReplay: 'https://sr.example.com',
+      });
+    });
+
+    it('returns undefined for empty endpoint with no trace and no realm', () => {
+      expect(fromNativeEndpoint({})).toBeUndefined();
+    });
+  });
+
+  describe('fromNativeState', () => {
+    it('maps status and endpoint', () => {
+      const native: NativeState = {
+        appName: 'a',
+        appVersion: '1.0',
+        deploymentEnvironment: 'prod',
+        status: { type: 'NotRunning', reason: 'NotInstalled' },
+        endpoint: { trace: 't' },
+        isDebugLoggingEnabled: false,
+        instrumentedProcessName: null,
+        deferredUntilForeground: false,
+      };
+
+      const state = fromNativeState(native);
+
+      expect(state.status.type).toBe('NotRunning');
+      expect(state.endpoint).toEqual({ trace: 't' });
+    });
+
+    it('maps null endpoint to undefined', () => {
+      const native: NativeState = {
+        appName: 'a',
+        appVersion: '1.0',
+        deploymentEnvironment: 'prod',
+        status: { type: 'Running' },
+        endpoint: null,
+        isDebugLoggingEnabled: false,
+        instrumentedProcessName: null,
+        deferredUntilForeground: false,
+      };
+
+      const state = fromNativeState(native);
+
+      expect(state.endpoint).toBeUndefined();
+    });
+
+    it('maps Running status', () => {
+      const native: NativeState = {
+        appName: 'myApp',
+        appVersion: '2.0',
+        deploymentEnvironment: 'staging',
+        status: { type: 'Running' },
+        endpoint: { realm: 'eu0', rumAccessToken: 'x' },
+        isDebugLoggingEnabled: true,
+        instrumentedProcessName: 'main',
+        deferredUntilForeground: true,
+      };
+
+      const state = fromNativeState(native);
+
+      expect(state.status).toEqual({ type: 'Running' });
+      expect(state.appName).toBe('myApp');
+      expect(state.appVersion).toBe('2.0');
+      expect(state.deploymentEnvironment).toBe('staging');
+      expect(state.isDebugLoggingEnabled).toBe(true);
+      expect(state.instrumentedProcessName).toBe('main');
+      expect(state.deferredUntilForeground).toBe(true);
+      expect(state.endpoint).toEqual({
+        realm: 'eu0',
+        rumAccessToken: 'x',
+      });
+    });
   });
 });

--- a/packages/core/src/__tests__/provider.test.tsx
+++ b/packages/core/src/__tests__/provider.test.tsx
@@ -18,11 +18,42 @@ import React from 'react';
 import { SplunkRumProvider } from '../providers/SplunkRumProvider';
 
 describe('SplunkRumProvider', () => {
-  it('returns a React element', () => {
+  it('returns a React element with endpoint', () => {
     const element = (
       <SplunkRumProvider
         agentConfiguration={{
           endpoint: { trace: 't' },
+          appName: 'app',
+          deploymentEnvironment: 'prod',
+        }}
+      >
+        <></>
+      </SplunkRumProvider>
+    );
+
+    expect(React.isValidElement(element)).toBe(true);
+  });
+
+  it('returns a React element without endpoint', () => {
+    const element = (
+      <SplunkRumProvider
+        agentConfiguration={{
+          appName: 'app',
+          deploymentEnvironment: 'prod',
+        }}
+      >
+        <></>
+      </SplunkRumProvider>
+    );
+
+    expect(React.isValidElement(element)).toBe(true);
+  });
+
+  it('returns a React element with realm endpoint', () => {
+    const element = (
+      <SplunkRumProvider
+        agentConfiguration={{
+          endpoint: { realm: 'us0', rumAccessToken: 'tok' },
           appName: 'app',
           deploymentEnvironment: 'prod',
         }}

--- a/packages/core/src/api/AgentPreferences.ts
+++ b/packages/core/src/api/AgentPreferences.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { EndpointConfiguration } from '../model/configuration/EndpointConfiguration';
+import { SplunkNativeBridge as Native } from '../sdk/SplunkNativeBridge';
+import { toNativeEndpoint } from '../bridge/converters';
+
+/**
+ * Agent preferences for runtime configuration.
+ *
+ * Use this to dynamically configure agent settings after initialization.
+ * Accessible via `SplunkRum.instance.preferences`.
+ *
+ * @example Setting endpoint after install
+ * ```typescript
+ * await SplunkRum.install({
+ *   appName: 'MyApp',
+ *   deploymentEnvironment: 'production',
+ * });
+ *
+ * // Later, configure the endpoint
+ * await SplunkRum.instance.preferences.setEndpointConfiguration({
+ *   realm: 'us0',
+ *   rumAccessToken: 'YOUR_TOKEN',
+ * });
+ * ```
+ *
+ * @example Clearing the endpoint
+ * ```typescript
+ * await SplunkRum.instance.preferences.setEndpointConfiguration(null);
+ * ```
+ */
+export class AgentPreferences {
+  /**
+   * Sets the endpoint configuration for the RUM agent.
+   *
+   * - Setting a non-null value configures the endpoint and starts sending buffered data.
+   * - Setting `null` disables the endpoint.
+   *
+   * @param endpoint - Endpoint configuration, or `null`.
+   */
+  async setEndpointConfiguration(
+    endpoint: EndpointConfiguration | null
+  ): Promise<void> {
+    const native = endpoint ? toNativeEndpoint(endpoint) : null;
+
+    return Native.setEndpointConfiguration(native);
+  }
+}

--- a/packages/core/src/api/AgentPreferences.ts
+++ b/packages/core/src/api/AgentPreferences.ts
@@ -16,7 +16,7 @@
 
 import type { EndpointConfiguration } from '../model/configuration/EndpointConfiguration';
 import { SplunkNativeBridge as Native } from '../sdk/SplunkNativeBridge';
-import { toNativeEndpoint } from '../bridge/converters';
+import { toNativeEndpoint, fromNativeEndpoint } from '../bridge/converters';
 
 /**
  * Agent preferences for runtime configuration.
@@ -38,12 +38,26 @@ import { toNativeEndpoint } from '../bridge/converters';
  * });
  * ```
  *
+ * @example Reading the current endpoint
+ * ```typescript
+ * const endpoint = await SplunkRum.instance.preferences.getEndpointConfiguration();
+ * ```
+ *
  * @example Clearing the endpoint
  * ```typescript
  * await SplunkRum.instance.preferences.setEndpointConfiguration(null);
  * ```
  */
 export class AgentPreferences {
+  /**
+   * Returns the current endpoint configuration, or `undefined` when
+   * no endpoint has been configured.
+   */
+  async getEndpointConfiguration(): Promise<EndpointConfiguration | undefined> {
+    const native = await Native.getEndpointConfiguration();
+    return fromNativeEndpoint(native);
+  }
+
   /**
    * Sets the endpoint configuration for the RUM agent.
    *
@@ -56,7 +70,6 @@ export class AgentPreferences {
     endpoint: EndpointConfiguration | null
   ): Promise<void> {
     const native = endpoint ? toNativeEndpoint(endpoint) : null;
-
     return Native.setEndpointConfiguration(native);
   }
 }

--- a/packages/core/src/api/SplunkRum.ts
+++ b/packages/core/src/api/SplunkRum.ts
@@ -22,6 +22,7 @@ import { Session } from './Session';
 import { User } from './User';
 import { CustomTracking } from './CustomTracking';
 import { Navigation } from './Navigation';
+import { AgentPreferences } from './AgentPreferences';
 import { MutableAttributes } from '../model/attributes/MutableAttributes';
 import {
   toNativeAgentConfiguration,
@@ -35,16 +36,27 @@ import {
  * Use `SplunkRum.install()` to initialize the SDK, then access features
  * via `SplunkRum.instance`.
  *
- * @example Basic usage
+ * @example Basic usage with endpoint
  * ```typescript
  * await SplunkRum.install({
  *   endpoint: { realm: 'us0', rumAccessToken: 'YOUR_TOKEN' },
  *   appName: 'MyApp',
  *   deploymentEnvironment: 'production',
  * });
+ * ```
  *
- * // Access SDK features
- * await SplunkRum.instance.globalAttributes.setString('user.tier', 'premium');
+ * @example Deferred endpoint configuration
+ * ```typescript
+ * await SplunkRum.install({
+ *   appName: 'MyApp',
+ *   deploymentEnvironment: 'production',
+ * });
+ *
+ * // Configure endpoint later via preferences
+ * await SplunkRum.instance.preferences.setEndpointConfiguration({
+ *   realm: 'us0',
+ *   rumAccessToken: 'YOUR_TOKEN',
+ * });
  * ```
  */
 export class SplunkRum {
@@ -87,6 +99,13 @@ export class SplunkRum {
 
     return this._instance!;
   }
+
+  /**
+   * Agent preferences for runtime configuration.
+   *
+   * Allows configuring settings like endpoint after initialization.
+   */
+  readonly preferences = new AgentPreferences();
 
   /**
    * Global attributes sent with all signals.

--- a/packages/core/src/api/State.ts
+++ b/packages/core/src/api/State.ts
@@ -47,8 +47,8 @@ export interface SplunkRumState {
   deploymentEnvironment: string;
   /** Current agent status. */
   status: SplunkRumStatus;
-  /** Configured endpoint. */
-  endpoint: EndpointConfiguration;
+  /** Configured endpoint, or `undefined` when no endpoint has been set. */
+  endpoint?: EndpointConfiguration;
   /** Whether debug logging is enabled. */
   isDebugLoggingEnabled: boolean;
   /** Instrumented process name. **Android only.** */

--- a/packages/core/src/bridge/converters.ts
+++ b/packages/core/src/bridge/converters.ts
@@ -44,7 +44,9 @@ export function toNativeAgentConfiguration(
   configuration: AgentConfiguration
 ): NativeAgentConfiguration {
   return {
-    endpoint: toNativeEndpoint(configuration.endpoint),
+    endpoint: configuration.endpoint
+      ? toNativeEndpoint(configuration.endpoint)
+      : null,
     appName: configuration.appName,
     deploymentEnvironment: configuration.deploymentEnvironment,
     appVersion: configuration.appVersion ?? null,
@@ -66,18 +68,24 @@ export function toNativeModules(
   return modules.map((m) => m.toNative());
 }
 
-export function fromNativeEndpoint(ep: NativeEndpoint): EndpointConfiguration {
-  if (ep && ep.realm) {
+export function fromNativeEndpoint(
+  ep: NativeEndpoint | null | undefined
+): EndpointConfiguration | undefined {
+  if (!ep) return undefined;
+
+  if (ep.realm) {
     return {
       realm: String(ep.realm),
       rumAccessToken: String(ep.rumAccessToken ?? ''),
     };
   }
 
+  if (!ep.trace) return undefined;
+
   return {
-    trace: String(ep?.trace ?? ''),
+    trace: String(ep.trace),
     sessionReplay:
-      ep?.sessionReplay != null ? String(ep.sessionReplay) : undefined,
+      ep.sessionReplay != null ? String(ep.sessionReplay) : undefined,
   };
 }
 
@@ -98,7 +106,7 @@ export function fromNativeState(native: NativeState): SplunkRumState {
     appVersion: String(native.appVersion ?? ''),
     deploymentEnvironment: String(native.deploymentEnvironment ?? ''),
     status,
-    endpoint: fromNativeEndpoint(native.endpoint),
+    endpoint: fromNativeEndpoint(native.endpoint) ?? undefined,
     isDebugLoggingEnabled: !!native.isDebugLoggingEnabled,
     instrumentedProcessName: native.instrumentedProcessName ?? null,
     deferredUntilForeground: !!native.deferredUntilForeground,

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -16,6 +16,7 @@
 
 export { SplunkRum } from './api/SplunkRum';
 export { SplunkRumProvider } from './providers/SplunkRumProvider';
+export { AgentPreferences } from './api/AgentPreferences';
 export type { AgentConfiguration } from './model/configuration/AgentConfiguration';
 export type { EndpointConfiguration } from './model/configuration/EndpointConfiguration';
 export type {

--- a/packages/core/src/model/configuration/AgentConfiguration.ts
+++ b/packages/core/src/model/configuration/AgentConfiguration.ts
@@ -27,8 +27,10 @@ export interface AgentConfiguration {
    * Endpoint configuration defining URLs to the instrumentation collector.
    *
    * Use realm-based or custom URL configuration.
+   * When omitted, the agent starts without an endpoint and buffers data
+   * until one is configured via `SplunkRum.instance.preferences.endpointConfiguration`.
    */
-  endpoint: EndpointConfiguration;
+  endpoint?: EndpointConfiguration;
 
   /**
    * Application name displayed in the RUM dashboard.

--- a/packages/core/src/specs/NativeSplunkOtelReactNative.ts
+++ b/packages/core/src/specs/NativeSplunkOtelReactNative.ts
@@ -96,6 +96,7 @@ export interface Spec extends TurboModule {
   ): Promise<void>;
 
   // Preferences
+  getEndpointConfiguration(): Promise<NativeEndpoint | null>;
   setEndpointConfiguration(
     endpoint: { [key: string]: unknown } | null
   ): Promise<void>;

--- a/packages/core/src/specs/NativeSplunkOtelReactNative.ts
+++ b/packages/core/src/specs/NativeSplunkOtelReactNative.ts
@@ -41,7 +41,7 @@ export type NativeSession = {
 };
 
 export type NativeAgentConfiguration = {
-  endpoint: NativeEndpoint;
+  endpoint: NativeEndpoint | null;
   appName: string;
   deploymentEnvironment: string;
   appVersion: string | null;
@@ -75,7 +75,7 @@ export type NativeState = {
   appVersion: string;
   deploymentEnvironment: string;
   status: NativeStatus;
-  endpoint: NativeEndpoint;
+  endpoint: NativeEndpoint | null;
   isDebugLoggingEnabled: boolean;
   instrumentedProcessName: string | null;
   deferredUntilForeground: boolean;
@@ -93,6 +93,11 @@ export interface Spec extends TurboModule {
   install(
     configuration: { [key: string]: unknown },
     modules: Array<{ [key: string]: unknown }>
+  ): Promise<void>;
+
+  // Preferences
+  setEndpointConfiguration(
+    endpoint: { [key: string]: unknown } | null
   ): Promise<void>;
 
   // State and user/session


### PR DESCRIPTION
## Title: Make `EndpointConfiguration` optional

### Description

This PR implements the API bridging for recently introduced changes in natives that make the `EndpointConfiguration` optional. Additionally it introduces the `AgentPreferences` API for the deferred enpoint setting.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] (If applicable) I have added unit tests for my changes.
- [x] (If applicable) I have updated the sample app for integration testing.
- [x] (If applicable) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI