### PR TITLE
NO-TICKET: chore(github): add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,79 @@
+---
+name: Bug Report
+title: "Short descriptive title of the issue"
+description: "Report a bug or unexpected behavior encountered with the splunk-otel-react-native Agent."
+labels: bug
+body:
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: 1. Describe the Issue
+      description: A clear and concise description of what the bug is. What were you trying to achieve, and what went wrong?
+      placeholder: Describe the issue here...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: client-version
+    attributes:
+      label: 2. Agent Version
+      description: Please select the exact version of the `splunk-otel-react-native` agent you are using.
+      options:
+        - 1.0.0
+        - Other (please specify in "Additional Context")
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: 3. Steps to Reproduce (Scenario)
+      description: |
+        Steps to reproduce the behavior:
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+      placeholder: Provide detailed steps to reproduce the issue...
+    validations:
+      required: false
+
+  - type: textarea
+    id: affected-devices
+    attributes:
+      label: 4. Affected Devices / Android Versions
+      description: |
+        Please specify the device(s) and Android/iOS version(s) where you observed the issue.
+        Example:
+        - Device: Google Pixel 6, Android Version: 13 (API 33)
+        - Device: iPhone 13, iOS Version: 15
+      placeholder: e.g., Google Pixel 6 (Android 13), Samsung Galaxy S22 (Android 12)
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs-stack-trace
+    attributes:
+      label: 5. Relevant Logs / Stack Trace
+      description: If applicable, include any relevant React Native logs, JavaScript errors, native crash reports (Android/iOS), or stack traces. Please format them using code blocks.
+      placeholder: Paste logs or stack trace here...
+    validations:
+      required: false
+
+  - type: textarea
+    id: code-snippet
+    attributes:
+      label: 6. Code Snippet / Minimal Reproducible Example
+      description: If possible, provide a small code snippet or a link to a minimal reproducible example that demonstrates the issue. This helps in quickly understanding and debugging the problem.
+      placeholder: Provide a code snippet or link to a reproducible example...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: 7. Additional Context
+      description: Add any other context about the problem here. For example, if it only happens under specific network conditions, or after a certain period of time.
+      placeholder: Any other relevant information...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -41,13 +41,14 @@ body:
   - type: textarea
     id: affected-devices
     attributes:
-      label: 4. Affected Devices / Android Versions
+      label: 4. Affected Devices / OS Versions
       description: |
         Please specify the device(s) and Android/iOS version(s) where you observed the issue.
+        Include React Native version if relevant.
         Example:
-        - Device: Google Pixel 6, Android Version: 13 (API 33)
-        - Device: iPhone 13, iOS Version: 15
-      placeholder: e.g., Google Pixel 6 (Android 13), Samsung Galaxy S22 (Android 12)
+        - Device: Google Pixel 6, Android Version: 13 (API 33), React Native: 0.73.x
+        - Device: iPhone 13, iOS Version: 15, React Native: 0.73.x
+      placeholder: e.g., Google Pixel 6 (Android 13), iPhone 13 (iOS 15), React Native 0.7x
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Splunk RUM for React Native — Installation & Configuration
+    url: https://help.splunk.com/en/splunk-observability-cloud/manage-data/new-splunk-rum-agents/splunk-rum-react-native-agent/install-the-splunk-rum-react-native-agent
+    about: Setup, configuration, and usage documentation for the SDK.
+  - name: Splunk RUM for React Native — Troubleshooting
+    url: https://help.splunk.com/en/splunk-observability-cloud/manage-data/new-splunk-rum-agents/splunk-rum-react-native-agent/troubleshoot-react-native-instrumentation
+    about: Common issues and how to resolve them before filing a bug.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,17 @@
+name: Enhancement / Feature Request
+description: Submit an enhancement or feature request for the splunk-otel-android Agent.
+title: "Short descriptive title of the enhancement/feature request"
+labels: ["enhancement"]
+assignees:
+  - nehalmol
+  - SenNeonoveNoci
+  - aditi-s3
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Detailed Description
+      description: Please provide a detailed description of the enhancement or feature you are proposing. Explain the problem it solves or the new capability it introduces, and clearly describe the use case(s) where this enhancement would be beneficial.
+      placeholder: Describe your enhancement or feature request here...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,5 +1,5 @@
 name: Enhancement / Feature Request
-description: Submit an enhancement or feature request for the splunk-otel-android Agent.
+description: Submit an enhancement or feature request for the splunk-otel-react-native Agent.
 title: "Short descriptive title of the enhancement/feature request"
 labels: ["enhancement"]
 assignees:


### PR DESCRIPTION
Adds GitHub `ISSUE_TEMPLATES` to standardize bug reports and feature requests for `splunk-otel-react-native`.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI